### PR TITLE
feat: 혼자 패킹 카테고리 생성

### DIFF
--- a/src/main/java/packman/controller/aloneList/AloneListCategoryController.java
+++ b/src/main/java/packman/controller/aloneList/AloneListCategoryController.java
@@ -1,11 +1,31 @@
 package packman.controller.aloneList;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import packman.dto.category.CategoryCreateDto;
+import packman.service.aloneList.AloneListCategoryService;
+import packman.util.ResponseCode;
+import packman.util.ResponseMessage;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/list/alone/category")
 public class AloneListCategoryController {
+    private final AloneListCategoryService aloneListCategoryService;
+
+    @PostMapping
+    public ResponseEntity<ResponseMessage> createCategory(@RequestBody @Valid CategoryCreateDto categoryRequestDto, HttpServletRequest request) {
+        Long userId = 1L;
+        return ResponseMessage.toResponseEntity(
+                ResponseCode.SUCCESS_CREATE_ALONE_CATEGORY,
+                aloneListCategoryService.createCategory(categoryRequestDto, userId)
+        );
+    }
 }

--- a/src/main/java/packman/dto/category/CategoryCreateDto.java
+++ b/src/main/java/packman/dto/category/CategoryCreateDto.java
@@ -1,0 +1,16 @@
+package packman.dto.category;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class CategoryCreateDto {
+    @NotNull
+    private String name;
+    @NotNull
+    private String listId;
+
+}

--- a/src/main/java/packman/dto/category/CategoryInfo.java
+++ b/src/main/java/packman/dto/category/CategoryInfo.java
@@ -1,0 +1,15 @@
+package packman.dto.category;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import packman.dto.pack.PackInfo;
+
+import java.util.List;
+
+@JsonPropertyOrder({"id", "name", "pack"})
+public interface CategoryInfo {
+    String getId();
+
+    String getName();
+
+    List<PackInfo> getPack();
+}

--- a/src/main/java/packman/dto/category/CategoryResponseDto.java
+++ b/src/main/java/packman/dto/category/CategoryResponseDto.java
@@ -1,0 +1,9 @@
+package packman.dto.category;
+
+import java.util.List;
+
+public interface CategoryResponseDto {
+    String getId();
+
+    List<CategoryInfo> getCategory();
+}

--- a/src/main/java/packman/dto/pack/PackInfo.java
+++ b/src/main/java/packman/dto/pack/PackInfo.java
@@ -1,0 +1,17 @@
+package packman.dto.pack;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import packman.dto.user.PackerInfo;
+
+import java.util.Optional;
+
+@JsonPropertyOrder({"id", "name", "isChecked", "packer"})
+public interface PackInfo {
+    String getId();
+
+    String getName();
+
+    boolean getIsChecked();
+
+    Optional<PackerInfo> getPacker();
+}

--- a/src/main/java/packman/dto/user/PackerInfo.java
+++ b/src/main/java/packman/dto/user/PackerInfo.java
@@ -1,0 +1,7 @@
+package packman.dto.user;
+
+public interface PackerInfo {
+    String getId();
+
+    String getNickname();
+}

--- a/src/main/java/packman/entity/Category.java
+++ b/src/main/java/packman/entity/Category.java
@@ -27,8 +27,13 @@ public class Category {
 
     @Column(length = 12, nullable = false)
     private String name;
-
+    @OrderBy("id asc")
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
-    private List<Pack> packs = new ArrayList<>();
+    private List<Pack> pack = new ArrayList<>();
+
+    public Category(PackingList packingList, String name) {
+        this.packingList = packingList;
+        this.name = name;
+    }
 
 }

--- a/src/main/java/packman/entity/Pack.java
+++ b/src/main/java/packman/entity/Pack.java
@@ -1,5 +1,6 @@
 package packman.entity;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,7 +29,11 @@ public class Pack {
 
     @Column(length = 12, nullable = false)
     private String name;
-
+    @Getter(AccessLevel.NONE)
     @Column(nullable = false)
     private boolean isChecked = false;
+
+    public boolean getIsChecked() {
+        return this.isChecked;
+    }
 }

--- a/src/main/java/packman/entity/packingList/PackingList.java
+++ b/src/main/java/packman/entity/packingList/PackingList.java
@@ -35,13 +35,19 @@ public class PackingList extends TimeStamped {
 
     @Column(nullable = false)
     private boolean isDeleted = false;
-
+    @OrderBy("id asc")
     @OneToMany(mappedBy = "packingList", cascade = CascadeType.ALL)
-    private List<Category> categories = new ArrayList<>();
+    private List<Category> category = new ArrayList<>();
 
     @OneToOne(mappedBy = "packingList", cascade = CascadeType.ALL)
     private AlonePackingList alonePackingList;
 
     @OneToOne(mappedBy = "packingList", cascade = CascadeType.ALL)
     private TogetherPackingList togetherPackingList;
+
+    public void addCategory(Category category) {
+        this.category.add(category);
+    }
+
+
 }

--- a/src/main/java/packman/repository/packingList/PackingListRepository.java
+++ b/src/main/java/packman/repository/packingList/PackingListRepository.java
@@ -2,8 +2,14 @@ package packman.repository.packingList;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import packman.entity.Folder;
+import packman.dto.category.CategoryResponseDto;
+import packman.entity.packingList.PackingList;
+
+import java.util.Optional;
 
 @Repository
-public interface PackingListRepository extends JpaRepository<Folder, Long> {
+public interface PackingListRepository extends JpaRepository<PackingList, Long> {
+    Optional<PackingList> findByIdAndIsDeleted(Long listId, boolean isDeleted);
+
+    CategoryResponseDto findByIdAndTitle(Long listId, String title);
 }

--- a/src/main/java/packman/service/aloneList/AloneListCategoryService.java
+++ b/src/main/java/packman/service/aloneList/AloneListCategoryService.java
@@ -3,9 +3,49 @@ package packman.service.aloneList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import packman.dto.category.CategoryCreateDto;
+import packman.dto.category.CategoryResponseDto;
+import packman.entity.Category;
+import packman.entity.packingList.PackingList;
+import packman.repository.CategoryRepository;
+import packman.repository.packingList.PackingListRepository;
+import packman.util.CustomException;
+import packman.util.ResponseCode;
+
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class AloneListCategoryService {
+    private final PackingListRepository packingListRepository;
+    private final CategoryRepository categoryRepository;
+
+    public CategoryResponseDto createCategory(CategoryCreateDto categoryCreateDto, Long userId) {
+
+        // 카테고리 exceed_len
+        if (categoryCreateDto.getName().length() > 12) {
+            throw new CustomException(ResponseCode.EXCEED_LEN);
+        }
+        // no_list
+        PackingList packingList = packingListRepository.findByIdAndIsDeleted(Long.parseLong(categoryCreateDto.getListId()), false).orElseThrow(
+                () -> new CustomException(ResponseCode.NO_LIST)
+        );
+        // duplicate_category
+        List<Category> categorys = packingList.getCategory();
+        categorys.stream().forEach(category -> {
+            if (category.getName().equals(categoryCreateDto.getName())) {
+                throw new CustomException(ResponseCode.DUPLICATED_CATEGORY);
+            }
+        });
+        // insert
+        Category category = new Category(packingList, categoryCreateDto.getName());
+        packingList.addCategory(category);
+        packingListRepository.save(packingList);
+
+
+        // response
+        CategoryResponseDto categoryResponseDto = packingListRepository.findByIdAndTitle(Long.parseLong(categoryCreateDto.getListId()), packingList.getTitle());
+        return categoryResponseDto;
+    }
 }

--- a/src/main/java/packman/util/ResponseCode.java
+++ b/src/main/java/packman/util/ResponseCode.java
@@ -12,9 +12,17 @@ public enum ResponseCode {
     NULL_VALUE(HttpStatus.BAD_REQUEST, false, "필요한 값이 없습니다"),
     NOT_FOUND(HttpStatus.NOT_FOUND, false, "존재하지 않는 자원"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류입니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류입니다"),
 
+    // alonePackingList
+    SUCCESS_CREATE_ALONE_CATEGORY(HttpStatus.OK, true, "혼자 패킹리스트 카테고리 생성 성공"),
 
+    // category
+    DUPLICATED_CATEGORY(HttpStatus.BAD_REQUEST, false, "중복된 카테고리 명입니다"),
+    // packingList
+
+    NO_LIST(HttpStatus.BAD_REQUEST, false, "존재하지 않는 패킹리스트입니다"),
+    EXCEED_LEN(HttpStatus.BAD_REQUEST, false, "제한된 글자수를 초과하였습니다");
 
     private final HttpStatus httpStatus;
     private final Boolean success;


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-10](https://packman-team.atlassian.net/browse/PS-10)

## ✏️ Task
- 혼자 패킹 카테고리 생성

## 💡 Review Point
- Response 데이터의 순서를 고정하는 annotation
  `@JsonPropertyOrder({ "id", "name", "listNum" })`
- onetomany관계에서는 pk를 가지고 있는 쪽이 관계의 주체가 되어 생성을 관리한다. list-category관계에서는 list에서 관리


[PS-10]: https://packman-team.atlassian.net/browse/PS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ