### PR TITLE
feat: 임시 userId를 accessToken으로 가져온 id로 변경 

### DIFF
--- a/src/main/java/packman/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/packman/auth/JwtAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (jwtTokenProvider.isValidateToken(accessToken).equals("ok")) {  // token 검증
             String userId = setAuthentication(accessToken);
+
             if (userId == null) {
                 setErrorResponse(response, ResponseCode.NO_USER);
                 return;

--- a/src/main/java/packman/auth/SecurityConfig.java
+++ b/src/main/java/packman/auth/SecurityConfig.java
@@ -75,7 +75,8 @@ public class SecurityConfig {
         return web -> {
             web.ignoring()
                     .antMatchers(
-                            "/auth/**"
+                            "/auth/**",
+                            "/list/*/share/**"
                     );
         };
     }

--- a/src/main/java/packman/controller/FolderController.java
+++ b/src/main/java/packman/controller/FolderController.java
@@ -22,7 +22,7 @@ public class FolderController {
 
     @GetMapping("/alone")
     public ResponseEntity<ResponseMessage> getAloneFolders(HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_ALONE_FOLDERS,
@@ -32,7 +32,7 @@ public class FolderController {
 
     @GetMapping("/together")
     public ResponseEntity<ResponseMessage> getTogetherFolders(HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_TOGETHER_FOLDERS,
@@ -42,7 +42,7 @@ public class FolderController {
 
     @GetMapping("/list/alone/{folderId}")
     public ResponseEntity<ResponseMessage> getAloneListsInFolder(@PathVariable Long folderId, HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_ALONE_LISTS_IN_FOLDER,
@@ -52,7 +52,7 @@ public class FolderController {
 
     @GetMapping("/list/together/{folderId}")
     public ResponseEntity<ResponseMessage> getTogetherListsInFolder(@PathVariable Long folderId, HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_TOGETHER_LISTS_IN_FOLDER,
@@ -62,7 +62,8 @@ public class FolderController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createFolder(@RequestBody @Valid FolderRequestDto folderRequestDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_FOLDER,
                 folderService.createFolder(folderRequestDto, userId)
@@ -71,7 +72,8 @@ public class FolderController {
 
     @GetMapping
     public ResponseEntity<ResponseMessage> getFolders(HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_FOLDERS,
                 folderService.getFolders(userId)
@@ -80,7 +82,8 @@ public class FolderController {
 
     @PatchMapping
     public ResponseEntity<ResponseMessage> updateFolder(@RequestBody @Valid FolderUpdateRequestDto folderUpdateRequestDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_FOLDER,
                 folderService.updateFolder(folderUpdateRequestDto, userId)
@@ -89,7 +92,7 @@ public class FolderController {
 
     @GetMapping("/recentCreatedList")
     public ResponseEntity<ResponseMessage> getRecentCreatedList(HttpServletRequest request) {
-        Long userId = 3L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         if (folderService.getRecentCreatedList(userId) == null) {
             return ResponseMessage.toResponseEntity(

--- a/src/main/java/packman/controller/ListController.java
+++ b/src/main/java/packman/controller/ListController.java
@@ -24,7 +24,7 @@ public class ListController {
      */
     @PatchMapping("/title")
     public ResponseEntity<ResponseMessage> updateTitle(@RequestBody @Valid ListTitleRequestDto listTitleRequestDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.UPDATE_LIST_TITLE_SUCCESS,
@@ -37,7 +37,7 @@ public class ListController {
      */
     @PatchMapping("/departureDate")
     public ResponseEntity<ResponseMessage> updateDepartureDate(@RequestBody @Valid DepartureDateRequestDto departureDateRequestDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.UPDATE_LIST_DEPARTURE_DATE_SUCCESS,
@@ -47,7 +47,7 @@ public class ListController {
 
     @PatchMapping("/myTemplate")
     public ResponseEntity<ResponseMessage> updateMyTempalte(@RequestBody @Valid TemplateUpdateDto templateUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.UPDATE_LIST_MY_TEMPLATE_SUCCESS,
@@ -57,7 +57,7 @@ public class ListController {
 
     @GetMapping("/{listId}/title-date")
     public ResponseEntity<ResponseMessage> getPackingListTitleAndDate(@PathVariable Long listId, @RequestParam boolean isAloned, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.GET_LIST_TITLE_DEPARTURE_DATE_SUCCESS,
@@ -65,7 +65,8 @@ public class ListController {
         );
     }
     @GetMapping("/{listType}/share/{inviteCode}")
-    public ResponseEntity<ResponseMessage> getInviteTogetherList(@PathVariable("listType") String listType, @PathVariable("inviteCode") String inviteCode, HttpServletRequest request) {
+    public ResponseEntity<ResponseMessage> getInviteTogetherList(@PathVariable("listType") String listType, @PathVariable("inviteCode") String inviteCode) {
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_INVITE_LIST,
                 listService.getInviteList(listType, inviteCode)

--- a/src/main/java/packman/controller/MemberController.java
+++ b/src/main/java/packman/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
 
     @GetMapping("/{listId}")
     public ResponseEntity<ResponseMessage> getMember(@PathVariable @NotBlank String listId, HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_MEMBER,
@@ -32,7 +32,7 @@ public class MemberController {
 
     @DeleteMapping("/{groupId}/{memberId}")
     public ResponseEntity<ResponseNonDataMessage> deleteMember(@PathVariable Long groupId, @PathVariable List<Long> memberId, HttpServletRequest request) {
-        Long userId = 1L;  // 임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         memberService.deleteMember(userId, groupId, memberId);
 

--- a/src/main/java/packman/controller/TemplateController.java
+++ b/src/main/java/packman/controller/TemplateController.java
@@ -20,7 +20,7 @@ public class TemplateController {
 
     @GetMapping("/alone")
     public ResponseEntity<ResponseMessage> getAloneTemplateList(HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_ALONE_TEMPLATE_LIST,
@@ -30,7 +30,7 @@ public class TemplateController {
 
     @GetMapping("/together")
     public ResponseEntity<ResponseMessage> getTogetherTemplateList(HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_TOGETHER_TEMPLATE_LIST,
@@ -40,7 +40,8 @@ public class TemplateController {
 
     @GetMapping("/{templateId}")
     public ResponseEntity<ResponseMessage> getTemplate(@PathVariable Long templateId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_DETAILED_TEMPLATE,
                 templateService.getTemplate(templateId, userId)

--- a/src/main/java/packman/controller/UserController.java
+++ b/src/main/java/packman/controller/UserController.java
@@ -20,7 +20,7 @@ public class UserController {
 
     @GetMapping
     public ResponseEntity<ResponseMessage> getUser(HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_USER,
@@ -30,7 +30,7 @@ public class UserController {
 
     @DeleteMapping
     public ResponseEntity<ResponseNonDataMessage> deleteUser(HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         userService.deleteUser(userId);
 
@@ -41,7 +41,7 @@ public class UserController {
 
     @PatchMapping("/profile")
     public ResponseEntity<ResponseMessage> updateUser(@RequestBody @Valid UserUpdateDto userUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_USER,

--- a/src/main/java/packman/controller/aloneList/AloneListCategoryController.java
+++ b/src/main/java/packman/controller/aloneList/AloneListCategoryController.java
@@ -21,7 +21,8 @@ public class AloneListCategoryController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createCategory(@RequestBody @Valid CategoryCreateDto categoryRequestDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_ALONE_CATEGORY,
                 aloneListCategoryService.createCategory(categoryRequestDto, userId)
@@ -30,7 +31,8 @@ public class AloneListCategoryController {
 
     @PatchMapping
     public ResponseEntity<ResponseMessage> updateCategory(@RequestBody @Valid CategoryUpdateDto categoryUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_ALONE_CATEGORY,
                 aloneListCategoryService.updateCategory(categoryUpdateDto, userId)
@@ -39,7 +41,8 @@ public class AloneListCategoryController {
 
     @DeleteMapping("/{listId}/{categoryId}")
     public ResponseEntity<ResponseNonDataMessage> deleteCategory(@PathVariable("listId") Long listId, @PathVariable("categoryId") Long categoryId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         aloneListCategoryService.deleteCategory(listId, categoryId, userId);
         return ResponseNonDataMessage.toResponseEntity(
                 ResponseCode.SUCCESS_DELETE_ALONE_CATEGORY

--- a/src/main/java/packman/controller/aloneList/AloneListController.java
+++ b/src/main/java/packman/controller/aloneList/AloneListController.java
@@ -21,7 +21,7 @@ public class AloneListController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createAloneList(@RequestBody @Valid ListCreateDto listCreateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_ALONE_LIST,
@@ -31,7 +31,7 @@ public class AloneListController {
 
     @GetMapping("/{listId}")
     public ResponseEntity<ResponseMessage> getAloneList(@PathVariable("listId") Long listId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_ALONE_LIST,
@@ -41,7 +41,7 @@ public class AloneListController {
 
     @DeleteMapping("/{folderId}/{listId}")
     public ResponseEntity<ResponseNonDataMessage> deleteAloneList(@PathVariable("folderId") Long folderId, @PathVariable("listId") List<Long> listIds, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         aloneListService.deleteAloneList(userId, folderId, listIds);
 
@@ -52,7 +52,7 @@ public class AloneListController {
 
     @GetMapping("/invite/{inviteCode}")
     public ResponseEntity<ResponseMessage> getInviteAloneList(@PathVariable String inviteCode, HttpServletRequest request) {
-        Long userId = 1L;  //  임시 userId 1
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_INVITE_ALONE_LIST,

--- a/src/main/java/packman/controller/aloneList/AloneListPackController.java
+++ b/src/main/java/packman/controller/aloneList/AloneListPackController.java
@@ -24,7 +24,7 @@ public class AloneListPackController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createPack(@RequestBody @Valid PackCreateDto packCreateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_ALONE_PACK,
@@ -34,7 +34,7 @@ public class AloneListPackController {
 
     @PatchMapping
     public ResponseEntity<ResponseMessage> updatePack(@RequestBody @Valid PackUpdateDto packUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_ALONE_PACK,
@@ -45,7 +45,7 @@ public class AloneListPackController {
     @DeleteMapping("/{listId}/{categoryId}/{packId}")
     public ResponseEntity<ResponseNonDataMessage> deletePack(
             @PathVariable @NotBlank String listId, @PathVariable @NotBlank String categoryId, @PathVariable @NotBlank String packId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         packService.deleteAlonePack(Long.valueOf(listId), Long.valueOf(categoryId), Long.valueOf(packId), userId);
 

--- a/src/main/java/packman/controller/togetherList/TogetherListCategoryController.java
+++ b/src/main/java/packman/controller/togetherList/TogetherListCategoryController.java
@@ -22,7 +22,8 @@ public class TogetherListCategoryController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createCategory(@RequestBody @Valid CategoryCreateDto categoryCreateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_TOGETHER_CATEGORY,
                 togetherListCategoryService.createCategory(categoryCreateDto, userId)
@@ -31,7 +32,8 @@ public class TogetherListCategoryController {
 
     @PatchMapping
     public ResponseEntity<ResponseMessage> updateCategory(@RequestBody @Valid CategoryUpdateDto categoryUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_TOGETHER_CATEGORY,
                 togetherListCategoryService.updateCategory(categoryUpdateDto, userId)
@@ -40,7 +42,8 @@ public class TogetherListCategoryController {
 
     @DeleteMapping("/{listId}/{categoryId}")
     public ResponseEntity<ResponseNonDataMessage> deleteCategory(@PathVariable("listId") Long listId, @PathVariable("categoryId") Long categoryId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         togetherListCategoryService.deleteCategory(listId, categoryId, userId);
         return ResponseNonDataMessage.toResponseEntity(
                 ResponseCode.SUCCESS_DELETE_TOGETHER_CATEGORY

--- a/src/main/java/packman/controller/togetherList/TogetherListController.java
+++ b/src/main/java/packman/controller/togetherList/TogetherListController.java
@@ -3,9 +3,9 @@ package packman.controller.togetherList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import packman.dto.togetherList.PackerUpdateDto;
 import packman.dto.list.ListCreateDto;
 import packman.dto.member.MemberAddDto;
+import packman.dto.togetherList.PackerUpdateDto;
 import packman.service.togetherList.TogetherListService;
 import packman.util.ResponseCode;
 import packman.util.ResponseMessage;
@@ -24,7 +24,7 @@ public class TogetherListController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createTogetherList(@RequestBody @Valid ListCreateDto listCreateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_TOGETHER_LIST,
@@ -34,7 +34,7 @@ public class TogetherListController {
 
     @DeleteMapping("/{folderId}/{listId}")
     public ResponseEntity<ResponseNonDataMessage> deleteTogetherList(@PathVariable("folderId") Long folderId, @PathVariable("listId") List<Long> listIds, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         togetherListService.deleteTogetherList(userId, folderId, listIds);
 
@@ -45,7 +45,8 @@ public class TogetherListController {
 
     @GetMapping("/invite/{inviteCode}")
     public ResponseEntity<ResponseMessage> getInviteTogetherList(@PathVariable("inviteCode") String inviteCode, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_INVITE_TOGETHER_PACKING,
                 togetherListService.getInviteTogetherList(userId, inviteCode)
@@ -54,7 +55,7 @@ public class TogetherListController {
 
     @GetMapping("/{listId}")
     public ResponseEntity<ResponseMessage> getTogetherList(@PathVariable("listId") Long listId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_GET_TOGETHER_LIST,
@@ -64,7 +65,7 @@ public class TogetherListController {
 
     @PatchMapping("/packer")
     public ResponseEntity<ResponseMessage> updatePacker(@RequestBody @Valid PackerUpdateDto packerUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_PACKER,
@@ -73,9 +74,9 @@ public class TogetherListController {
     }
 
     @PostMapping("/add-member")
-    public ResponseEntity<ResponseMessage> addMember(@RequestBody @Valid MemberAddDto
-                                                             memberAddDto, HttpServletRequest httpServletRequest) {
-        Long userId = 5L;
+    public ResponseEntity<ResponseMessage> addMember(@RequestBody @Valid MemberAddDto memberAddDto, HttpServletRequest request) {
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_ADD_MEMBER,
                 togetherListService.addMember(memberAddDto, userId)

--- a/src/main/java/packman/controller/togetherList/TogetherListPackController.java
+++ b/src/main/java/packman/controller/togetherList/TogetherListPackController.java
@@ -24,7 +24,7 @@ public class TogetherListPackController {
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createPack(@RequestBody @Valid PackCreateDto packCreateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_CREATE_TOGETHER_PACK,
@@ -34,7 +34,7 @@ public class TogetherListPackController {
 
     @PatchMapping
     public ResponseEntity<ResponseMessage> updatePack(@RequestBody @Valid PackUpdateDto packUpdateDto, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         return ResponseMessage.toResponseEntity(
                 ResponseCode.SUCCESS_UPDATE_TOGETHER_PACK,
@@ -45,7 +45,7 @@ public class TogetherListPackController {
     @DeleteMapping("/{listId}/{categoryId}/{packId}")
     public ResponseEntity<ResponseNonDataMessage> deletePack(
             @PathVariable @NotBlank String listId, @PathVariable @NotBlank String categoryId, @PathVariable @NotBlank String packId, HttpServletRequest request) {
-        Long userId = 1L;
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
 
         packService.deleteTogetherPack(Long.valueOf(listId), Long.valueOf(categoryId), Long.valueOf(packId), userId);
 


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-64](https://packman-team.atlassian.net/browse/PS-64?atlOrigin=eyJpIjoiMmRlMmFkYWRlZjlkNGQzNTg3ZTdiZTI5MzdlNmNiNTYiLCJwIjoiaiJ9)

## ✏️ Task
- 임시 userId를 accessToken으로 가져온 id로 변경 

## 💡 Review Point
- 공유된 패킹리스트 조회의 경우 accessToken을 검사하지 않음으로 security관련 필터 제외 url에 추가해줬습니다.


[PS-64]: https://packman-team.atlassian.net/browse/PS-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ