### PR TITLE
chore: 필요 없는 user 검증 제거

### DIFF
--- a/src/main/java/packman/service/FolderService.java
+++ b/src/main/java/packman/service/FolderService.java
@@ -30,8 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static packman.validator.IdValidator.validateUserId;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -229,7 +227,6 @@ public class FolderService {
     }
 
     public RecentCreatedListResponseDto getRecentCreatedList(Long userId) {
-        validateUserId(userRepository, userId);
 
         List<AlonePackingList> alonePackingLists = alonePackingListRepository.findByFolderPackingList_Folder_UserIdOrderByIdDesc(userId);
 

--- a/src/main/java/packman/service/ListService.java
+++ b/src/main/java/packman/service/ListService.java
@@ -56,9 +56,6 @@ public class ListService {
         Long aloneListId = listId;
         String title = listTitleRequestDto.getTitle();
 
-        //유저 검증
-        validateUserId(userRepository, userId);
-
         //제목 글자수 검증
         validateListLength(title);
 
@@ -83,9 +80,6 @@ public class ListService {
         Long listId = Long.parseLong(departureDateRequestDto.getId());
         Long aloneListId = listId;
         LocalDate departureDate = LocalDate.parse(departureDateRequestDto.getDepartureDate(), DateTimeFormatter.ISO_DATE);
-
-        //유저 검증
-        validateUserId(userRepository, userId);
 
         if (!departureDateRequestDto.getIsAloned()) {
             TogetherAlonePackingList togetherAlonePackingList = togetherAlonePackingListRepository.findById(listId).orElseThrow(

--- a/src/main/java/packman/service/MemberService.java
+++ b/src/main/java/packman/service/MemberService.java
@@ -36,7 +36,6 @@ public class MemberService {
     private final TogetherListService togetherListService;
 
     public MemberResponseDto getMember(Long userId, Long listId) {
-        validateUserId(userRepository, userId);
         TogetherPackingList togetherPackingList = validateTogetherAlonePackingListId(togetherAlonePackingListRepository, listId).getTogetherPackingList();
         PackingList packingList = togetherPackingList.getPackingList();
 
@@ -69,7 +68,6 @@ public class MemberService {
     }
 
     public void deleteMember(Long userId, Long groupId, List<Long> memberIds) {
-        validateUserId(userRepository, userId);
         Group group = validateGroupId(groupRepository, groupId);
 
         validateMemberId(userRepository, memberIds);

--- a/src/main/java/packman/service/PackService.java
+++ b/src/main/java/packman/service/PackService.java
@@ -18,7 +18,6 @@ import packman.repository.packingList.TogetherPackingListRepository;
 import packman.validator.Validator;
 
 import static packman.validator.IdValidator.validateCategoryId;
-import static packman.validator.IdValidator.validateUserId;
 import static packman.validator.LengthValidator.validatePackLength;
 import static packman.validator.Validator.*;
 
@@ -36,7 +35,6 @@ public class PackService {
     public ListResponseMapping createAlonePack(PackCreateDto packCreateDto, Long userId) {
         Long aloneListId = Long.valueOf(packCreateDto.getListId());
 
-        validateUserId(userRepository, userId);
         PackingList packingList = validateUserAloneList(userId, aloneListId, alonePackingListRepository, packingListRepository);
 
         addPackInCategory(packCreateDto, packingList);
@@ -47,7 +45,6 @@ public class PackService {
     public ListResponseMapping createTogetherPack(PackCreateDto packCreateDto, Long userId) {
         Long togetherListId = Long.valueOf(packCreateDto.getListId());
 
-        validateUserId(userRepository, userId);
         PackingList packingList = validateTogetherList(userId, togetherListId, packingListRepository, togetherPackingListRepository);
 
         addPackInCategory(packCreateDto, packingList);
@@ -71,7 +68,6 @@ public class PackService {
     public ListResponseMapping updateAlonePack(PackUpdateDto packUpdateDto, Long userId) {
         Long aloneListId = Long.valueOf(packUpdateDto.getListId());
 
-        validateUserId(userRepository, userId);
         PackingList packingList = validateUserAloneList(userId, aloneListId, alonePackingListRepository, packingListRepository);
 
         updatePackInCategory(packUpdateDto, packingList);
@@ -82,7 +78,6 @@ public class PackService {
     public ListResponseMapping updateTogetherPack(PackUpdateDto packUpdateDto, Long userId) {
         Long togetherListId = Long.valueOf(packUpdateDto.getListId());
 
-        validateUserId(userRepository, userId);
         PackingList packingList = Validator.validateTogetherList(userId, togetherListId, packingListRepository, togetherPackingListRepository);
 
         updatePackInCategory(packUpdateDto, packingList);
@@ -103,14 +98,12 @@ public class PackService {
     }
 
     public void deleteAlonePack(Long listId, Long categoryId, Long packId, Long userId) {
-        validateUserId(userRepository, userId);
         PackingList packingList = validateUserAloneList(userId, listId, alonePackingListRepository, packingListRepository);
 
         packRepository.delete(validateListCategoryPack(packingList, categoryId, packId, categoryRepository, packRepository));
     }
 
     public void deleteTogetherPack(Long listId, Long categoryId, Long packId, Long userId) {
-        validateUserId(userRepository, userId);
         PackingList packingList = validateTogetherList(userId, listId, packingListRepository, togetherPackingListRepository);
 
         packRepository.delete(validateListCategoryPack(packingList, categoryId, packId, categoryRepository, packRepository));

--- a/src/main/java/packman/service/TemplateService.java
+++ b/src/main/java/packman/service/TemplateService.java
@@ -24,8 +24,6 @@ public class TemplateService {
     private final UserRepository userRepository;
 
     public TemplateListResponseDto getAloneTemplateList(Long userId) {
-        // 유저 검증
-        validateUserId(userRepository, userId);
 
         TemplateListResponseDto templateListResponseDto = TemplateListResponseDto.builder()
                 .basicTemplate(templateRepository.findByUserIdAndIsAlonedAndIsDeleted(null, true, false))
@@ -35,8 +33,6 @@ public class TemplateService {
     }
 
     public TemplateListResponseDto getTogetherTemplateList(Long userId) {
-        // 유저 검증
-        validateUserId(userRepository, userId);
 
         TemplateListResponseDto templateListResponseDto = TemplateListResponseDto.builder()
                 .basicTemplate(templateRepository.findByUserIdAndIsAlonedAndIsDeleted(null, false, false))

--- a/src/main/java/packman/service/aloneList/AloneListService.java
+++ b/src/main/java/packman/service/aloneList/AloneListService.java
@@ -57,9 +57,6 @@ public class AloneListService {
             inviteCode = RandomStringUtils.randomAlphanumeric(5);
         } while (alonePackingListRepository.existsByInviteCode(inviteCode));
 
-        // 유저 검증
-        validateUserId(userRepository, userId);
-
         // 유저 소유 폴더 X 함께 패킹리스트 폴더 or 존재하지 않는 폴더의 경우
         Folder folder = validateUserFolder(folderRepository, folderId, userId, true);
 
@@ -109,8 +106,6 @@ public class AloneListService {
     }
 
     public DetailedAloneListResponseDto getAloneList(Long listId, Long userId) {
-        // 유저 검증(삭제 안된 유저)
-        validateUserId(userRepository, userId);
 
         // 유저의 혼자 패킹리스트인지 검증
         FolderPackingList folderPackingList = validateUserAloneListId(folderPackingListRepository, userId, listId);
@@ -128,9 +123,6 @@ public class AloneListService {
     }
 
     public void deleteAloneList(Long userId, Long folderId, List<Long> listIds) {
-
-        // 유저 검증(삭제 안된 유저)
-        validateUserId(userRepository, userId);
 
         // 유저 소유 폴더, 혼자 패킹리스트 폴더인지 검증
         validateUserFolder(folderRepository, folderId, userId, true);
@@ -152,7 +144,6 @@ public class AloneListService {
     }
 
     public InviteAloneListResponseDto getInviteAloneList(Long userId, String inviteCode) {
-        validateUserId(userRepository, userId);
         AlonePackingList alonePackingList = validateAlonePackingListByInviteCode(alonePackingListRepository, inviteCode);
         Long ownerId = alonePackingList.getFolderPackingList().getFolder().getUser().getId();
 

--- a/src/main/java/packman/service/togetherList/TogetherListService.java
+++ b/src/main/java/packman/service/togetherList/TogetherListService.java
@@ -150,9 +150,6 @@ public class TogetherListService {
         List<Group> groups = new ArrayList<>();
         List<PackingList> lists = new ArrayList<>(); //최종적으로 삭제할 packingList들을 담는 리스트
 
-        // 존재하는 유저인지 검증
-        validateUserId(userRepository, userId);
-
         // 유저 소유 폴더, 함께 패킹리스트 폴더인지 검증
         validateUserFolder(folderRepository, folderId, userId, false);
 
@@ -227,8 +224,6 @@ public class TogetherListService {
     }
 
     public DetaildTogetherListResponseDto getTogetherList(Long listId, Long userId) {
-        // 유저 검증
-        validateUserId(userRepository, userId);
         // 존재하는 함께 패킹리스트인지 검증
         TogetherAlonePackingList togetherAloneList = validateTogetherAlonePackingListIdInDetail(togetherAlonePackingListRepository, listId);
         // 유저의 함께 패킹리스트인지 검증 및 folderId 찾기


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-66](https://packman-team.atlassian.net/browse/PS-66?atlOrigin=eyJpIjoiOTdkZWNlODZiMTg0NDRkZTk3ZWMzYzQ4MDg0OGJlNTMiLCJwIjoiaiJ9)

## ✏️ Task
- 필요 없는 user 검증 제거

## 💡 Review Point
- 인증 성공 시 자동적으로 유저 검증(findByIdAndIsDeleted 이용)을 한 후 인증 객체를 SecurityContextHolder에 담도록 구현해서(by 멋쟁이 현지언니👻👍) service 단의 유저 검증은 필요가 없어졌습니다! 
- 따라서 validateUserId의 리턴 값을 사용하지 않고 단순히 validateUserId만 사용하는 경우는 해당 코드를 삭제했습니다~


[PS-66]: https://packman-team.atlassian.net/browse/PS-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ