### PR TITLE
feat: 유저 탈퇴 api 수정

### DIFF
--- a/src/main/java/packman/repository/FolderRepository.java
+++ b/src/main/java/packman/repository/FolderRepository.java
@@ -1,6 +1,9 @@
 package packman.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import packman.dto.folder.FolderIdNameMapping;
 import packman.entity.Folder;
@@ -23,5 +26,8 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Optional<Folder> findByUserIdAndNameAndIsAloned(Long userId, String name, boolean isAloned);
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Folder f where f.id = :folderId")
+    void deleteFolderByFolderId(@Param("folderId") Long folderId);
 }
 

--- a/src/main/java/packman/repository/UserRepository.java
+++ b/src/main/java/packman/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package packman.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import packman.entity.User;
 
@@ -11,4 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdAndIsDeleted(Long userId, boolean isDeleted);
 
     Optional<User> findByEmail(String email);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update User u set u.isDeleted = true where u.id = :userId")
+    void setUserIsDeletedByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/packman/service/FolderService.java
+++ b/src/main/java/packman/service/FolderService.java
@@ -15,17 +15,16 @@ import packman.entity.User;
 import packman.entity.packingList.AlonePackingList;
 import packman.entity.packingList.PackingList;
 import packman.repository.CategoryRepository;
-import packman.entity.packingList.TogetherAlonePackingList;
 import packman.repository.FolderPackingListRepository;
 import packman.repository.FolderRepository;
 import packman.repository.UserRepository;
 import packman.repository.packingList.AlonePackingListRepository;
 import packman.repository.packingList.PackingListRepository;
 import packman.repository.packingList.TogetherAlonePackingListRepository;
+import packman.service.aloneList.AloneListService;
 import packman.service.togetherList.TogetherListService;
 import packman.util.CustomException;
 import packman.util.ResponseCode;
-import packman.service.aloneList.AloneListService;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -299,7 +298,6 @@ public class FolderService {
         }
 
         // 폴더 삭제
-        folderRepository.deleteById(folderId);
-
+        folderRepository.deleteFolderByFolderId(folderId);
     }
 }

--- a/src/main/java/packman/service/UserService.java
+++ b/src/main/java/packman/service/UserService.java
@@ -68,7 +68,7 @@ public class UserService {
                 () -> new CustomException(ResponseCode.NO_USER)
         );
 
-        user.setDeleted(true);
+        userRepository.setUserIsDeletedByUserId(userId);
     }
 
     public UserInfoResponseDto updateUser(UserUpdateDto userUpdateDto, Long userId) {

--- a/src/main/java/packman/service/UserService.java
+++ b/src/main/java/packman/service/UserService.java
@@ -5,13 +5,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import packman.auth.JwtTokenProvider;
 import packman.dto.user.UserCreateDto;
-import packman.dto.user.UserResponseDto;
 import packman.dto.user.UserInfoResponseDto;
+import packman.dto.user.UserResponseDto;
 import packman.dto.user.UserUpdateDto;
+import packman.entity.Folder;
 import packman.entity.User;
 import packman.repository.UserRepository;
 import packman.util.CustomException;
 import packman.util.ResponseCode;
+
+import java.util.List;
 
 import static packman.validator.IdValidator.validateUserId;
 import static packman.validator.LengthValidator.validateUserNicknameLength;
@@ -22,6 +25,7 @@ import static packman.validator.LengthValidator.validateUserNicknameLength;
 public class UserService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final FolderService folderService;
 
     public UserResponseDto createUser(UserCreateDto userCreateDto) {
         //닉네임 글자수 제한
@@ -56,6 +60,7 @@ public class UserService {
                 .refreshToken(refreshToken)
                 .path(createdUser.getPath()).build();
     }
+
     public UserInfoResponseDto getUser(Long userId) {
         User user = userRepository.findByIdAndIsDeleted(userId, false).orElseThrow(
                 () -> new CustomException(ResponseCode.NO_USER)
@@ -64,12 +69,17 @@ public class UserService {
     }
 
     public void deleteUser(Long userId) {
-        User user = userRepository.findByIdAndIsDeleted(userId, false).orElseThrow(
-                () -> new CustomException(ResponseCode.NO_USER)
-        );
+        User user = userRepository.findByIdAndIsDeleted(userId, false).orElseThrow(() -> new CustomException(ResponseCode.NO_USER));
+
+        List<Folder> folders = user.getFolders();
+
+        for (Folder folder : folders) {
+            folderService.deleteFolder(folder.getId(), userId);
+        }
 
         userRepository.setUserIsDeletedByUserId(userId);
     }
+
 
     public UserInfoResponseDto updateUser(UserUpdateDto userUpdateDto, Long userId) {
         User user = validateUserId(userRepository, userId);


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-67](https://packman-team.atlassian.net/browse/PS-67?atlOrigin=eyJpIjoiZDg4N2VkMmRiOWJkNGU2ZGI0ZGRjYjM2OTVmMTQ5OGUiLCJwIjoiaiJ9)

## ✏️ Task
- 유저 탈퇴 api에서 유저의 폴더들을 삭제하도록 구현

## 💡 Review Point
- service안에 service 함수를 불러와서 사용하다보니 기존 `deleteById`, `setDeleted` 메서드를 사용했을 때 제대로 삭제되지 않는 현상이 발생해서 해당 부분은 따로 query문을 작성하여 해결하였습니다.


[PS-67]: https://packman-team.atlassian.net/browse/PS-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ