### PR TITLE
feat: 토큰 재발급 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation group: 'com.auth0', name: 'java-jwt', version: '3.16.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/packman/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/packman/auth/JwtAuthenticationFilter.java
@@ -29,7 +29,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
         String accessToken = jwtTokenProvider.resolveAccessToken((HttpServletRequest) request);  // header에서 가져온 accessToken
 
-
         if (jwtTokenProvider.isValidateToken(accessToken).equals("ok")) {  // token 검증
             String userId = setAuthentication(accessToken);
 
@@ -55,6 +54,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
+    // token으로 userId 얻기
     private String setAuthentication(String jwtToken) {
         try {
             Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken);  // 인증 객체 생성

--- a/src/main/java/packman/auth/JwtTokenProvider.java
+++ b/src/main/java/packman/auth/JwtTokenProvider.java
@@ -81,7 +81,14 @@ public class JwtTokenProvider {
 
     // Request의 Header에서 token값을 가져옴
     public String resolveAccessToken(HttpServletRequest request) {
-        return request.getHeader(AUTHORIZATION_HEADER);
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            return "";
+        } else {
+            return header.split(" ")[1];
+        }
+
     }
 
     public String resolveRefreshToken(HttpServletRequest request) {

--- a/src/main/java/packman/controller/AuthController.java
+++ b/src/main/java/packman/controller/AuthController.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import packman.auth.JwtTokenProvider;
+import packman.dto.auth.AuthKakaoRequestDto;
 import packman.dto.auth.KakaoLoginNewUserResponseDto;
 import packman.dto.auth.KakaoLoginResponseDto;
-import packman.dto.auth.AuthKakaoRequestDto;
 import packman.service.AuthService;
 import packman.util.ResponseCode;
 import packman.util.ResponseMessage;
@@ -20,7 +20,6 @@ import javax.validation.Valid;
 public class AuthController {
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
-
 
     @PostMapping("/kakao")
     public ResponseEntity<ResponseMessage> kakaoLogin(@RequestBody @Valid AuthKakaoRequestDto authKakaoRequestDto) {
@@ -46,5 +45,15 @@ public class AuthController {
                 ResponseCode.SUCCESS_KAKAO_LOGIN,
                 kakaoUserProfile
         );
+    }
+
+    @GetMapping("/token")
+    public ResponseEntity<ResponseMessage> getNewToken(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveAccessToken(request);
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+
+        return ResponseMessage.toResponseEntity(
+                ResponseCode.SUCCESS_GET_NEW_TOKEN,
+                authService.getNewToken(accessToken, refreshToken));
     }
 }

--- a/src/main/java/packman/dto/auth/NewTokenResponseDto.java
+++ b/src/main/java/packman/dto/auth/NewTokenResponseDto.java
@@ -1,0 +1,11 @@
+package packman.dto.auth;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NewTokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/packman/repository/UserRepository.java
+++ b/src/main/java/packman/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdAndIsDeleted(Long userId, boolean isDeleted);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByIdAndRefreshToken(Long userId, String refreshToken);
 }

--- a/src/main/java/packman/service/AuthService.java
+++ b/src/main/java/packman/service/AuthService.java
@@ -1,5 +1,6 @@
 package packman.service;
 
+import com.auth0.jwt.JWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,12 @@ import packman.auth.JwtTokenProvider;
 import packman.dto.auth.*;
 import packman.entity.User;
 import packman.repository.UserRepository;
+import packman.util.CustomException;
+import packman.util.ResponseCode;
 
 import java.util.Optional;
+
+import static packman.validator.Validator.validateUserRefreshToken;
 
 @Service
 @Transactional
@@ -160,5 +165,30 @@ public class AuthService {
         }
 
         return kakaoTokenDto.getAccess_token();
+    }
+
+    public NewTokenResponseDto getNewToken(String accessToken, String refreshToken) {
+        Long userId = Long.valueOf(JWT.decode(accessToken).getSubject());
+
+        validateUserRefreshToken(userRepository, userId, refreshToken);
+
+        String validateAccessToken = jwtTokenProvider.isValidateToken(accessToken);
+        String validateRefreshToken = jwtTokenProvider.isValidateToken(refreshToken);
+
+        if (validateRefreshToken.equals("expired_token")) {
+            throw new CustomException(ResponseCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        if (validateAccessToken.equals("expired_token")) {
+            String newAccessToken = jwtTokenProvider.createAccessToken(userId.toString());
+
+            return NewTokenResponseDto.builder()
+                    .accessToken(newAccessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        }
+
+        // 둘 다 만료되지 않음
+        throw new CustomException(ResponseCode.VALID_ACCESS_TOKEN);
     }
 }

--- a/src/main/java/packman/util/ResponseCode.java
+++ b/src/main/java/packman/util/ResponseCode.java
@@ -22,6 +22,10 @@ public enum ResponseCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, false, "만료된 토큰입니다"),
     INVALIDE_TOKEN(HttpStatus.UNAUTHORIZED, false, "유효하지 않은 토큰입니다"),
     NO_TOKEN(HttpStatus.UNAUTHORIZED, false, "토큰이 없습니다"),
+    NO_USER_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, false, "유저의 리프레쉬 토큰이 아닙니다"),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, false, "만료된 리프레쉬 토큰입니다"),
+    VALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, false, "유효한 토큰입니다"),
+    NO_BEARER_TOKEN(HttpStatus.UNAUTHORIZED, false, "Bearer Token 형식이 아닙니다"),
 
     // user
     SUCCESS_GET_USER(HttpStatus.OK, true, "유저 조회 성공"),

--- a/src/main/java/packman/validator/Validator.java
+++ b/src/main/java/packman/validator/Validator.java
@@ -4,10 +4,8 @@ import lombok.RequiredArgsConstructor;
 import packman.entity.*;
 import packman.entity.packingList.AlonePackingList;
 import packman.entity.packingList.PackingList;
-import packman.entity.packingList.TogetherPackingList;
-import packman.repository.FolderPackingListRepository;
-import packman.repository.FolderRepository;
 import packman.entity.packingList.TogetherAlonePackingList;
+import packman.entity.packingList.TogetherPackingList;
 import packman.entity.template.Template;
 import packman.repository.*;
 import packman.repository.packingList.AlonePackingListRepository;
@@ -172,6 +170,12 @@ public class Validator {
     public static TogetherPackingList validateTogetherPackingListByInviteCode(TogetherPackingListRepository togetherPackingListRepository, String inviteCode) {
         return togetherPackingListRepository.findByInviteCode(inviteCode).orElseThrow(
                 () -> new CustomException(ResponseCode.NO_LIST)
+        );
+    }
+
+    public static User validateUserRefreshToken(UserRepository userRepository, Long userId, String refreshToken) {
+        return userRepository.findByIdAndRefreshToken(userId, refreshToken).orElseThrow(
+                () -> new CustomException(ResponseCode.NO_USER_REFRESH_TOKEN)
         );
     }
 }


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-47](https://packman-team.atlassian.net/browse/PS-47?atlOrigin=eyJpIjoiYmY4ODY4YTNkMjk3NDhjNDkyZDc4YjU2ODYxMmE3M2YiLCJwIjoiaiJ9)

## ✏️ Task
- 토큰 재발급 API 구현

## 💡 Review Point
- JWT토큰을 사용할때 `Authorization` 타입으로 `Bearer`를 사용해서 해당 부분 구현했습니다. 기존처럼 Postman에서  Type으로 `Bearer Token` 선택한 다음 API 테스트 하면 잘 작동할꺼에유:)


[PS-47]: https://packman-team.atlassian.net/browse/PS-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ