### PR TITLE
fix: 폴더 안 패킹리스트 조회, 최근 생성된 리스트 조회, 짐 생성 버그 해결

### DIFF
--- a/src/main/java/packman/controller/FolderController.java
+++ b/src/main/java/packman/controller/FolderController.java
@@ -12,7 +12,6 @@ import packman.util.ResponseNonDataMessage;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import java.util.Collection;
 import java.util.Collections;
 
 @RestController

--- a/src/main/java/packman/repository/CategoryRepository.java
+++ b/src/main/java/packman/repository/CategoryRepository.java
@@ -5,7 +5,9 @@ import org.springframework.stereotype.Repository;
 import packman.dto.category.CategoryPackMapping;
 import packman.entity.Category;
 
+import java.util.List;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    CategoryPackMapping findByPackingListId(Long listId);
+    List<CategoryPackMapping> findByPackingListId(Long listId);
 }

--- a/src/main/java/packman/service/FolderService.java
+++ b/src/main/java/packman/service/FolderService.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static packman.validator.IdValidator.validateUserId;
 import static packman.validator.Validator.validateFolder;
 
 @Service
@@ -134,14 +133,17 @@ public class FolderService {
         long packTotalNum = 0L;
         long packRemainNum = 0L;
 
+
         if (list.getCategory().size() != 0) {
-            CategoryPackMapping categoryPackMapping = categoryRepository.findByPackingListId(listId);
+            List<CategoryPackMapping> categoryPackMappings = categoryRepository.findByPackingListId(listId);
 
-            for (PackCountMapping packCountMapping : categoryPackMapping.getPack()) {
-                packTotalNum++;
+            for (CategoryPackMapping categoryPackMapping : categoryPackMappings) {
+                for (PackCountMapping packCountMapping : categoryPackMapping.getPack()) {
+                    packTotalNum++;
 
-                if (!packCountMapping.getIsChecked()) {
-                    packRemainNum++;
+                    if (!packCountMapping.getIsChecked()) {
+                        packRemainNum++;
+                    }
                 }
             }
         }

--- a/src/main/java/packman/service/PackService.java
+++ b/src/main/java/packman/service/PackService.java
@@ -11,7 +11,6 @@ import packman.entity.Pack;
 import packman.entity.packingList.PackingList;
 import packman.repository.CategoryRepository;
 import packman.repository.PackRepository;
-import packman.repository.UserRepository;
 import packman.repository.packingList.AlonePackingListRepository;
 import packman.repository.packingList.PackingListRepository;
 import packman.repository.packingList.TogetherPackingListRepository;
@@ -25,7 +24,6 @@ import static packman.validator.Validator.*;
 @Transactional
 @RequiredArgsConstructor
 public class PackService {
-    private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
     private final PackingListRepository packingListRepository;
     private final TogetherPackingListRepository togetherPackingListRepository;
@@ -53,7 +51,7 @@ public class PackService {
     }
 
     public void addPackInCategory(PackCreateDto packCreateDto, PackingList packingList) {
-        Long categoryId = Long.valueOf(packCreateDto.getListId());
+        Long categoryId = Long.valueOf(packCreateDto.getCategoryId());
         String packName = packCreateDto.getName();
 
         Category category = validateCategoryId(categoryRepository, categoryId);


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-70](https://packman-team.atlassian.net/browse/PS-70?atlOrigin=eyJpIjoiNWNmOWE2ZGIwMGFlNDZhZTk1OWJjMTA1NDY4NWE4MTIiLCJwIjoiaiJ9)

## ✏️ Task
- 폴더 안 패킹리스트 조회, 최근 생성된 리스트 조회에서 여러 카테고리의 짐 수를 세는 부분 수정
- 짐 생성 관련 api에서 잘못 대입한 categoryId 수정

## 💡 Review Point
- 


[PS-70]: https://packman-team.atlassian.net/browse/PS-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ