### PR TITLE
feat: 기본 템플릿 테이블 분리

### DIFF
--- a/src/main/java/packman/controller/BasicTemplateController.java
+++ b/src/main/java/packman/controller/BasicTemplateController.java
@@ -1,0 +1,30 @@
+package packman.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import packman.service.BasicTemplateService;
+import packman.util.ResponseCode;
+import packman.util.ResponseMessage;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/basicTemplate")
+public class BasicTemplateController {
+    private final BasicTemplateService basicTemplateService;
+
+    @GetMapping("/{templateId}")
+    public ResponseEntity<ResponseMessage> getBasicTemplate(@PathVariable Long templateId, HttpServletRequest request) {
+        Long userId = Long.valueOf(request.getUserPrincipal().getName());
+
+        return ResponseMessage.toResponseEntity(
+                ResponseCode.SUCCESS_GET_BASIC_DETAILED_TEMPLATE,
+                basicTemplateService.getBasicTemplate(templateId, userId)
+        );
+    }
+}

--- a/src/main/java/packman/entity/User.java
+++ b/src/main/java/packman/entity/User.java
@@ -5,6 +5,7 @@ import packman.dto.user.UserCreateDto;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import packman.entity.template.BasicTemplate;
 import packman.entity.template.Template;
 
 import javax.persistence.*;
@@ -62,6 +63,9 @@ public class User extends TimeStamped implements UserDetails {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Template> templates = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<BasicTemplate> basicTemplates = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserGroup> userGroups = new ArrayList<>();

--- a/src/main/java/packman/entity/packingList/AlonePackingList.java
+++ b/src/main/java/packman/entity/packingList/AlonePackingList.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import packman.entity.FolderPackingList;
+import packman.entity.template.BasicTemplate;
 import packman.entity.template.Template;
 
 import javax.persistence.*;
@@ -35,6 +36,9 @@ public class AlonePackingList {
 
     @OneToOne(mappedBy = "alonePackingList", cascade = CascadeType.ALL)
     private Template template;
+
+    @OneToOne(mappedBy = "alonePackingList", cascade = CascadeType.ALL)
+    private BasicTemplate basicTemplate;
 
     @OneToOne(mappedBy = "alonePackingList", cascade = CascadeType.ALL)
     private FolderPackingList folderPackingList;

--- a/src/main/java/packman/entity/template/BasicTemplate.java
+++ b/src/main/java/packman/entity/template/BasicTemplate.java
@@ -43,7 +43,7 @@ public class BasicTemplate extends TimeStamped {
 
     @OrderBy("id asc")
     @OneToMany(mappedBy = "basicTemplate", cascade = CascadeType.ALL)
-    private List<BasicTemplateCategory> basicTemplateCategories = new ArrayList<>();
+    private List<BasicTemplateCategory> categories = new ArrayList<>();
 
     public BasicTemplate(boolean isAloned, String title, AlonePackingList alonePackingList, User user){
         this.isAloned = isAloned;
@@ -52,5 +52,5 @@ public class BasicTemplate extends TimeStamped {
         this.user  = user;
     }
 
-    public void addTemplateCategory(BasicTemplateCategory basicTemplateCategory) { this.basicTemplateCategories.add(basicTemplateCategory); }
+    public void addTemplateCategory(BasicTemplateCategory basicTemplateCategory) { this.categories.add(basicTemplateCategory); }
 }

--- a/src/main/java/packman/entity/template/BasicTemplate.java
+++ b/src/main/java/packman/entity/template/BasicTemplate.java
@@ -1,0 +1,56 @@
+package packman.entity.template;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import packman.entity.TimeStamped;
+import packman.entity.User;
+import packman.entity.packingList.AlonePackingList;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class BasicTemplate extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "basic_template_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private boolean isAloned = true;
+
+    @Column(length = 12, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "alone_packing_list_id")
+    private AlonePackingList alonePackingList;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OrderBy("id asc")
+    @OneToMany(mappedBy = "basicTemplate", cascade = CascadeType.ALL)
+    private List<BasicTemplateCategory> basicTemplateCategories = new ArrayList<>();
+
+    public BasicTemplate(boolean isAloned, String title, AlonePackingList alonePackingList, User user){
+        this.isAloned = isAloned;
+        this.title = title;
+        this.alonePackingList = alonePackingList;
+        this.user  = user;
+    }
+
+    public void addTemplateCategory(BasicTemplateCategory basicTemplateCategory) { this.basicTemplateCategories.add(basicTemplateCategory); }
+}

--- a/src/main/java/packman/entity/template/BasicTemplateCategory.java
+++ b/src/main/java/packman/entity/template/BasicTemplateCategory.java
@@ -29,11 +29,11 @@ public class BasicTemplateCategory {
 
     @OrderBy("id asc")
     @OneToMany(mappedBy = "basicTemplateCategory", cascade = CascadeType.ALL)
-    private List<BasicTemplatePack> basicTemplatePacks = new ArrayList<>();
+    private List<BasicTemplatePack> templatePacks = new ArrayList<>();
 
     public BasicTemplateCategory(BasicTemplate basicTemplate, String name){
         this.basicTemplate = basicTemplate;
         this.name = name;
     }
-    public void addTemplatePack(BasicTemplatePack basicTemplatePacks) { this.basicTemplatePacks.add(basicTemplatePacks); }
+    public void addTemplatePack(BasicTemplatePack basicTemplatePacks) { this.templatePacks.add(basicTemplatePacks); }
 }

--- a/src/main/java/packman/entity/template/BasicTemplateCategory.java
+++ b/src/main/java/packman/entity/template/BasicTemplateCategory.java
@@ -1,0 +1,39 @@
+package packman.entity.template;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class BasicTemplateCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "basic_template_category_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "basic_template_id")
+    private BasicTemplate basicTemplate;
+
+    @Column(length = 12, nullable = false)
+    private String name;
+
+    @OrderBy("id asc")
+    @OneToMany(mappedBy = "basicTemplateCategory", cascade = CascadeType.ALL)
+    private List<BasicTemplatePack> basicTemplatePacks = new ArrayList<>();
+
+    public BasicTemplateCategory(BasicTemplate basicTemplate, String name){
+        this.basicTemplate = basicTemplate;
+        this.name = name;
+    }
+    public void addTemplatePack(BasicTemplatePack basicTemplatePacks) { this.basicTemplatePacks.add(basicTemplatePacks); }
+}

--- a/src/main/java/packman/entity/template/BasicTemplatePack.java
+++ b/src/main/java/packman/entity/template/BasicTemplatePack.java
@@ -1,0 +1,32 @@
+package packman.entity.template;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class BasicTemplatePack {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "basic_template_pack_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "basic_template_category_id")
+    private BasicTemplateCategory basicTemplateCategory;
+
+    @Column(length = 12, nullable = false)
+    private String name;
+
+    public BasicTemplatePack(BasicTemplateCategory basicTemplateCategory, String name){
+        this.basicTemplateCategory = basicTemplateCategory;
+        this.name = name;
+    }
+}

--- a/src/main/java/packman/repository/basicTemplate/BasicTemplateRepository.java
+++ b/src/main/java/packman/repository/basicTemplate/BasicTemplateRepository.java
@@ -1,0 +1,20 @@
+package packman.repository.basicTemplate;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import packman.dto.template.TemplateIdTitleMapping;
+import packman.dto.template.TemplateResponseMapping;
+import packman.entity.packingList.AlonePackingList;
+import packman.entity.template.BasicTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BasicTemplateRepository extends JpaRepository<BasicTemplate, Long> {
+    Optional<BasicTemplate> findByIdAndIsDeleted(Long templateId, boolean isDeleted);
+
+    List<TemplateIdTitleMapping> findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(Long userId, boolean isAloned, boolean isDeleted);
+
+    TemplateResponseMapping findProjectionById(Long templateId);
+}

--- a/src/main/java/packman/service/BasicTemplateService.java
+++ b/src/main/java/packman/service/BasicTemplateService.java
@@ -1,0 +1,37 @@
+package packman.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import packman.dto.template.TemplateResponseDto;
+import packman.dto.template.TemplateResponseMapping;
+import packman.entity.User;
+import packman.entity.template.BasicTemplate;
+import packman.repository.UserRepository;
+import packman.repository.basicTemplate.BasicTemplateRepository;
+
+import static packman.validator.IdValidator.validateBasicTemplateId;
+import static packman.validator.IdValidator.validateUserId;
+import static packman.validator.Validator.validateUserBasicTemplate;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BasicTemplateService {
+    private final BasicTemplateRepository basicTemplateRepository;
+    private final UserRepository userRepository;
+
+    public TemplateResponseDto getBasicTemplate(Long templateId, Long userId) {
+        User user = validateUserId(userRepository, userId);
+        BasicTemplate template = validateBasicTemplateId(basicTemplateRepository, templateId);
+
+        validateUserBasicTemplate(template, user);
+
+        TemplateResponseMapping templateResponseMapping = basicTemplateRepository.findProjectionById(template.getId());
+
+        return TemplateResponseDto.builder()
+                .id(templateResponseMapping.getId())
+                .title(templateResponseMapping.getTitle())
+                .category(templateResponseMapping.getCategories()).build();
+    }
+}

--- a/src/main/java/packman/service/TemplateService.java
+++ b/src/main/java/packman/service/TemplateService.java
@@ -9,6 +9,7 @@ import packman.dto.template.TemplateResponseMapping;
 import packman.entity.User;
 import packman.entity.template.Template;
 import packman.repository.UserRepository;
+import packman.repository.basicTemplate.BasicTemplateRepository;
 import packman.repository.template.TemplateRepository;
 import packman.util.LogMessage;
 
@@ -21,12 +22,13 @@ import static packman.validator.Validator.validateUserTemplate;
 @RequiredArgsConstructor
 public class TemplateService {
     private final TemplateRepository templateRepository;
+    private final BasicTemplateRepository basicTemplateRepository;
     private final UserRepository userRepository;
 
     public TemplateListResponseDto getAloneTemplateList(Long userId) {
 
         TemplateListResponseDto templateListResponseDto = TemplateListResponseDto.builder()
-                .basicTemplate(templateRepository.findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(null, true, false))
+                .basicTemplate(basicTemplateRepository.findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(null, true, false))
                 .myTemplate(templateRepository.findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(userId, true, false)).build();
 
         LogMessage.setNonDataLog("혼자 패킹 템플릿 리스트 조회", userId);
@@ -37,7 +39,7 @@ public class TemplateService {
     public TemplateListResponseDto getTogetherTemplateList(Long userId) {
 
         TemplateListResponseDto templateListResponseDto = TemplateListResponseDto.builder()
-                .basicTemplate(templateRepository.findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(null, false, false))
+                .basicTemplate(basicTemplateRepository.findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(null, false, false))
                 .myTemplate(templateRepository.findByUserIdAndIsAlonedAndIsDeletedOrderByCreatedAt(userId, false, false)).build();
 
         LogMessage.setNonDataLog("함께 패킹 템플릿 리스트 조회", userId);

--- a/src/main/java/packman/util/ResponseCode.java
+++ b/src/main/java/packman/util/ResponseCode.java
@@ -114,6 +114,10 @@ public enum ResponseCode {
     SUCCESS_GET_TOGETHER_TEMPLATE_LIST(HttpStatus.OK, true, "함께 패킹 템플릿 리스트 조회 성공"),
     SUCCESS_GET_DETAILED_TEMPLATE(HttpStatus.OK, true, "템플릿 상세조회 성공"),
 
+    // basic template
+    NO_BASIC_TEMPLATE(HttpStatus.NOT_FOUND, false, "존재하지 않는 기본 템플릿입니다"),
+    SUCCESS_GET_BASIC_DETAILED_TEMPLATE(HttpStatus.OK, true, "기본 템플릿 상세조회 성공"),
+
     // 엿보기
     SUCCESS_GET_HELP(HttpStatus.OK, true, "엿보기 조회 성공"),
     

--- a/src/main/java/packman/validator/IdValidator.java
+++ b/src/main/java/packman/validator/IdValidator.java
@@ -5,11 +5,13 @@ import packman.entity.packingList.AlonePackingList;
 import packman.entity.packingList.PackingList;
 import packman.entity.packingList.TogetherAlonePackingList;
 import packman.entity.packingList.TogetherPackingList;
+import packman.entity.template.BasicTemplate;
 import packman.entity.template.Template;
 import packman.repository.CategoryRepository;
 import packman.repository.FolderPackingListRepository;
 import packman.repository.PackRepository;
 import packman.repository.UserRepository;
+import packman.repository.basicTemplate.BasicTemplateRepository;
 import packman.repository.packingList.AlonePackingListRepository;
 import packman.repository.packingList.PackingListRepository;
 import packman.repository.packingList.TogetherAlonePackingListRepository;
@@ -37,6 +39,12 @@ public class IdValidator {
     }
     public static Template validateTemplateId(TemplateRepository templateRepository, Long templateId) {
         return templateRepository.findByIdAndIsDeleted(templateId, false).orElseThrow(
+                () -> new CustomException(ResponseCode.NO_TEMPLATE)
+        );
+    }
+
+    public static BasicTemplate validateBasicTemplateId(BasicTemplateRepository basicTemplateRepository, Long templateId) {
+        return basicTemplateRepository.findByIdAndIsDeleted(templateId, false).orElseThrow(
                 () -> new CustomException(ResponseCode.NO_TEMPLATE)
         );
     }

--- a/src/main/java/packman/validator/Validator.java
+++ b/src/main/java/packman/validator/Validator.java
@@ -6,6 +6,7 @@ import packman.entity.packingList.AlonePackingList;
 import packman.entity.packingList.PackingList;
 import packman.entity.packingList.TogetherAlonePackingList;
 import packman.entity.packingList.TogetherPackingList;
+import packman.entity.template.BasicTemplate;
 import packman.entity.template.Template;
 import packman.repository.*;
 import packman.repository.packingList.AlonePackingListRepository;
@@ -139,6 +140,13 @@ public class Validator {
             throw new CustomException(ResponseCode.NO_TEMPLATE);
         }
     }
+
+    public static void validateUserBasicTemplate(BasicTemplate basicTemplate, User user) {
+        if (basicTemplate.getUser() != null && basicTemplate.getUser() != user) {
+            throw new CustomException(ResponseCode.NO_TEMPLATE);
+        }
+    }
+
 
     public static List<FolderPackingList> validateFolderLists(FolderPackingListRepository folderPackingListRepository, Long folderId, List<Long> listIds) {
         List<FolderPackingList> folderPackingLists = folderPackingListRepository.findByFolderIdAndAlonePackingListIdIn(folderId, listIds);


### PR DESCRIPTION
## 🌱 Related Issue
- [PS-89](https://packman-team.atlassian.net/browse/PS-89)

## ✏️ Task
- 기존 혼자/함께 템플릿 조회에 기본 템플릿으로 조회로 갈아끼우기
- 기본 템플릿 상세조회 api 추가

## 💡 Review Point
- 상세조회의 경우에는 api를 분리할 수 밖에 없는 것 같아서 분리해서 구현했습니다. 
- template dto를 쓰기 위해서 (getCategories, getTemplatePacks ... ) basic template entity 일부 컬럼명을 template entity와 동일하게 수정했습니다.
